### PR TITLE
feat: for filesystem parsing return all files is base_path is None

### DIFF
--- a/saist/llm/adapters/ollama.py
+++ b/saist/llm/adapters/ollama.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class OllamaAdapter(BaseLlmAdapter):
     def __init__(self, base_url: str, model: str = None, api_key: Optional[str] = None):
         if model is None:
-            model = "llama3.2"
+            model = "llama3:latest"
         self.model = model
         self.client = ollama.AsyncClient(host=base_url)
 

--- a/saist/util/filtering.py
+++ b/saist/util/filtering.py
@@ -52,7 +52,7 @@ def should_process(filepath):
 include_patterns = load_patterns("saist.include")
 if not include_patterns:
     # Fallback to extension-based glob patterns like **/*.py
-    include_patterns = [f"**/*{ext}" for ext in DEFAULT_EXTENSIONS]
+    include_patterns = [f"**/*{ext}" for ext in DEFAULT_EXTENSIONS] + [f"*{ext}" for ext in DEFAULT_EXTENSIONS]
 ignore_patterns = load_patterns("saist.ignore")
 
 logger.info(f"include_patterns: {include_patterns}\nignore_patterns:{ignore_patterns}")


### PR DESCRIPTION
I think for filesystem file parsing it should return all matching files if the base path is None (nothing to compare changes to) plus a few linting tweaks.