### PR TITLE
Modify prompt using saist.rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ If multiple keys are defined, `PRE` and `POST` will wrap around the override tex
 
 ### 📝 `saist.rules.example`
 
+
 ```yaml
 # Example prompt modification
 
@@ -180,6 +181,7 @@ PROMPT_OVERRIDE: "Identify any potential vulnerabilites in the following code. F
 # Use these to prepend or append context to the prompt
 PROMPT_PRE: "You are reviewing critical code. Please be strict.\n\n"
 PROMPT_POST: "\n\nPlease provide practical advice."
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,34 @@ This setup will:
 
 ---
 
+## 🧠 Custom Prompt Rules 
+
+You can modify the system prompt used by creating a file named `saist.rules` in your working directory.
+
+This file supports the following YAML keys:
+
+PROMPT_OVERRIDE - Fully replaces the system prompt 
+PROMPT_PRE - Adds text before the existing prompt 
+PROMPT_POST - Adds text after the existing prompt 
+
+If multiple keys are defined, `PRE` and `POST` will wrap around the override text.
+
+---
+
+### 📝 `saist.rules.example`
+
+```yaml
+# Example prompt modification
+
+# Use this to completely override the system prompt:
+PROMPT_OVERRIDE: "Identify any potential vulnerabilites in the following code. Focus on input validation"
+
+# Use these to prepend or append context to the prompt
+PROMPT_PRE: "You are reviewing critical code. Please be strict.\n\n"
+PROMPT_POST: "\n\nPlease provide practical advice."
+
+---
+
 ## 🛣️ Roadmap
 
 - Ability to influence the prompts

--- a/saist.rules
+++ b/saist.rules
@@ -1,0 +1,8 @@
+# Example prompt modification
+
+# Use this to completely override the system prompt:
+# PROMPT_OVERRIDE: "Identify any potential vulnerabilites in the following code. Focus on input validation"
+
+# Use these to prepend or append context to the prompt
+PROMPT_PRE: "You are reviewing critical code. Please be strict.\n\n"
+PROMPT_POST: "\n\nPlease provide practical advice."

--- a/saist/main.py
+++ b/saist/main.py
@@ -42,7 +42,7 @@ async def analyze_single_file(scm: Scm, adapter: BaseLlmAdapter, filename, patch
     """
     Analyzes a SINGLE file diff with OpenAI, returning a Findings object or None on error.
     """
-    system_prompt = PromptRules.apply_rules(prompts.DETECT)
+    system_prompt = PromptRules.apply_rules(prompts.DETECT_PRE, prompts.DETECT_POST)
     logger.debug(f"Processing {filename}")
     prompt =(
         f"\n\nFile: {filename}\n{patch_text}\n"

--- a/saist/main.py
+++ b/saist/main.py
@@ -31,6 +31,8 @@ from util.poem import poem
 
 from util.output import print_banner, write_csv
 
+from util.rules import PromptRules
+
 prompts = prompts()
 load_dotenv(".env")
 
@@ -42,9 +44,9 @@ async def analyze_single_file(scm: Scm, adapter: BaseLlmAdapter, filename, patch
     """
     system_prompt = prompts.DETECT
     logger.debug(f"Processing {filename}")
-    prompt = (
+    prompt = PromptRules.apply_rules(
         f"\n\nFile: {filename}\n{patch_text}\n"
-    )
+        )
     try:
         return (await adapter.prompt_structured(system_prompt, prompt, Findings, [scm.read_file_contents])).findings
     except Exception as e:

--- a/saist/main.py
+++ b/saist/main.py
@@ -42,7 +42,7 @@ async def analyze_single_file(scm: Scm, adapter: BaseLlmAdapter, filename, patch
     """
     Analyzes a SINGLE file diff with OpenAI, returning a Findings object or None on error.
     """
-    system_prompt = PromptRules.apply_rules(prompts.DETECT_PRE, prompts.DETECT_POST)
+    system_prompt = PromptRules.apply_rules(prompts.DETECT)
     logger.debug(f"Processing {filename}")
     prompt =(
         f"\n\nFile: {filename}\n{patch_text}\n"

--- a/saist/main.py
+++ b/saist/main.py
@@ -42,9 +42,9 @@ async def analyze_single_file(scm: Scm, adapter: BaseLlmAdapter, filename, patch
     """
     Analyzes a SINGLE file diff with OpenAI, returning a Findings object or None on error.
     """
-    system_prompt = prompts.DETECT
+    system_prompt = PromptRules.apply_rules(prompts.DETECT)
     logger.debug(f"Processing {filename}")
-    prompt = PromptRules.apply_rules(
+    prompt =(
         f"\n\nFile: {filename}\n{patch_text}\n"
         )
     try:

--- a/saist/util/rules.py
+++ b/saist/util/rules.py
@@ -8,15 +8,22 @@ class PromptRules:
     RulesFile = "saist.rules"
 
     @staticmethod
-    def apply_rules(pre_prompt: str, post_prompt: str = "") -> str:
+    def apply_rules(prompt: str) -> str:
         rules = PromptRules.load_rules()
-    
-        override = rules.get("PROMPT_OVERRIDE")
-        pre = rules.get("PROMPT_PRE", "")
-        post = rules.get("PROMPT_POST", "")
 
-        final_prompt = override if override else (pre_prompt + post_prompt) #if override isn't specified, this should just use the prefix and suffix with the orig prompt
-        return f"{pre}{final_prompt}{post}"
+        override = rules.get("PROMPT_OVERRIDE")
+        pre = rules.get("PROMPT_PRE")
+        post = rules.get("PROMPT_POST")
+
+        final_prompt = override if override else prompt
+
+        if pre:
+            final_prompt = f"{pre}{final_prompt}"
+        if post:
+            final_prompt = f"{final_prompt}{post}"
+
+        return final_prompt
+
 
 
     @staticmethod
@@ -36,7 +43,7 @@ class PromptRules:
             else:
                 logger.debug("No valid keys found.")
 
-                return rules if rules is not None else {}
+            return rules if rules is not None else {}
         except Exception as ex:
             logger.error(f"Error reading saist.rules: {ex}")
             return {}

--- a/saist/util/rules.py
+++ b/saist/util/rules.py
@@ -12,19 +12,15 @@ class PromptRules:
         rules = PromptRules.load_rules()
 
         override = rules.get("PROMPT_OVERRIDE")
-        pre = rules.get("PROMPT_PRE")
-        post = rules.get("PROMPT_POST")
+        pre = rules.get("PROMPT_PRE", "")
+        post = rules.get("PROMPT_POST", "")
 
-        final_prompt = override if override else prompt
-
-        if pre:
-            final_prompt = f"{pre}{final_prompt}"
-        if post:
-            final_prompt = f"{final_prompt}{post}"
+        if override:
+            final_prompt = f"{pre}{override}{post}"
+        else:
+            final_prompt = f"{pre}{prompt}{post}"
 
         return final_prompt
-
-
 
     @staticmethod
     def load_rules():

--- a/saist/util/rules.py
+++ b/saist/util/rules.py
@@ -2,7 +2,7 @@ import os
 import yaml
 import logging
 
-logger = logging.getLogger("saist")
+logger = logging.getLogger(__name__) 
 
 class PromptRules:
     RulesFile = "saist.rules"
@@ -32,7 +32,7 @@ class PromptRules:
                 logger.debug(f"Loaded prompt rules: {', '.join(keys)}")
             else:
                 logger.debug("No valid keys found.")
-                
+
                 return rules if rules is not None else {}
         except Exception as ex:
             logger.error(f"Error reading saist.rules: {ex}")

--- a/saist/util/rules.py
+++ b/saist/util/rules.py
@@ -8,13 +8,16 @@ class PromptRules:
     RulesFile = "saist.rules"
 
     @staticmethod
-    def apply_rules(prompt):
+    def apply_rules(pre_prompt: str, post_prompt: str = "") -> str:
         rules = PromptRules.load_rules()
     
-        override = rules.get("PROMPT_OVERRIDE", prompt)
+        override = rules.get("PROMPT_OVERRIDE")
         pre = rules.get("PROMPT_PRE", "")
         post = rules.get("PROMPT_POST", "")
-        return f"{pre}{override}{post}"
+
+        final_prompt = override if override else (pre_prompt + post_prompt) #if override isn't specified, this should just use the prefix and suffix with the orig prompt
+        return f"{pre}{final_prompt}{post}"
+
 
     @staticmethod
     def load_rules():

--- a/saist/util/rules.py
+++ b/saist/util/rules.py
@@ -1,0 +1,39 @@
+import os
+import yaml
+
+class PromptRules:
+    RulesFile = "saist.rules"
+
+    @staticmethod
+    def apply_rules(prompt):
+        rules = PromptRules.load_rules()
+
+        override_prompt = rules.get("PROMPT_OVERRIDE")
+        if override_prompt:
+            #skip pre and post if override is present
+            return override_prompt
+
+        pre = rules.get("PROMPT_PRE", "")
+        post = rules.get("PROMPT_POST", "")
+
+        #add pre/post if they are present
+        return f"{pre}{prompt}{post}"
+
+    @staticmethod
+    def load_rules():
+        if not os.path.exists(PromptRules.RulesFile):
+            print("No saist.rules file found.")
+            return {} #return empty rules
+
+        try:
+            with open(PromptRules.RulesFile, 'r') as file:
+                yaml_content = file.read()
+                rules = yaml.safe_load(yaml_content) #using safe_load to prevent exploits (thank you stack overflow)
+                return rules if rules is not None else {}
+        except Exception as ex:
+            print("Error reading saist.rules: " + str(ex))
+            return {}
+
+#I first wrote this code in c# using dictionaries and a similar yaml parsing library for .net and then used a converter for python. 
+#I'm not too well versed with python yet but doing this excersise and seeing how things are converted, learning some syntax and hacking stuff together has been a massive help and has been really enjoyable!
+


### PR DESCRIPTION
- Created PromptRules class to read saist.rules from the working directory
- PROMPT_OVERRIDE to fully replace the prompt
- PROMPT_PRE and PROMPT_POST to modify prompt before/after
- Integrated apply_rules into analyze_single_file to adjust the prompt
- Falls back to original prompt if saist.rules doesn't exist or is empty