### PR TITLE
Fix should_process defaults to include files in root dir

### DIFF
--- a/saist/util/filtering.py
+++ b/saist/util/filtering.py
@@ -52,7 +52,7 @@ def should_process(filepath):
 include_patterns = load_patterns("saist.include")
 if not include_patterns:
     # Fallback to extension-based glob patterns like **/*.py
-    include_patterns = [f"**/*{ext}" for ext in DEFAULT_EXTENSIONS]
+    include_patterns = [f"*{ext}" for ext in DEFAULT_EXTENSIONS]
 ignore_patterns = load_patterns("saist.ignore")
 
 logger.info(f"include_patterns: {include_patterns}\nignore_patterns:{ignore_patterns}")


### PR DESCRIPTION
Changed the fallback include_patterns generation from \*/\*.extension to *.extension
This allows files in the root directory of the scan to be checked, not just files in subdirectories

fixes #28