### PR TITLE
Fix minted not breaking long lines of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .venv
 .vscode/**
+SAISTCache*
 build
 findings.csv
 report.pdf

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ export SAIST_LLM_API_KEY=your-api-key
 | Interactive shell after scanning | `saist/main.py --llm ollama --interactive filesystem /path/to/code` |
 | Export findings as CSV | `saist/main.py --llm openai --csv filesystem /path/to/code` |
 | Scan with docker and export findings as PDF report | `docker run -v <folder_path>:/vulnerableapp -v $PWD/reporting:/app/reporting punksecurity/saist --llm openai --pdf filesystem /vulnerableapp` |
+| Scan with docker and retain cache for future runs | `docker run -v <folder_path>:/vulnerableapp -v $PWD/reporting:/app/reporting -v $PWD/SAISTCache:/app/SAISTCache punksecurity/saist --llm openai filesystem /vulnerableapp` |
+| Change caching folder | `saist/main.py --llm openai --cache-folder /path/to/cache filesystem /path/to/code` |
+| Disable findings cache | `saist/main.py --llm openai --disable-caching filesystem /path/to/code` |
 ---
 
 ## 🗂️ File Filtering
@@ -162,6 +165,8 @@ docker run -v$PWD/code:/code -v$PWD/reporting:/app/reporting punksecurity/saist 
 | `--interactive` | Chat with the LLM after scan |
 | `--web` | Launch a local web server |
 | `--disable-tools` | Disable tool use during file analysis to reduce LLM token usage |
+| `--disable-caching` | Disable finding caching during file analysis |
+| `--cache-folder` | Change the default cache folder |
 | `--csv` | Output findings to `findings.csv` |
 | `--pdf` | Output findings to PDF report (`report.pdf`) |
 | `--ci` | Exit with code 1 if vulnerabilities found |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export SAIST_LLM_API_KEY=your-api-key
 | Interactive shell after scanning | `saist/main.py --llm ollama --interactive filesystem /path/to/code` |
 | Export findings as CSV | `saist/main.py --llm openai --csv filesystem /path/to/code` |
 | Scan with docker and export findings as PDF report | `docker run -v <folder_path>:/vulnerableapp -v $PWD/reporting:/app/reporting punksecurity/saist --llm openai --pdf filesystem /vulnerableapp` |
-| Scan with docker and retain cache for future runs | `docker run -v <folder_path>:/vulnerableapp -v $PWD/reporting:/app/reporting -v $PWD/SAISTCache:/app/SAISTCache punksecurity/saist --llm openai filesystem /vulnerableapp` |
+| Scan with docker and retain cache for future runs | `docker run -v <folder_path>:/vulnerableapp -v $PWD/SAISTCache:/app/SAISTCache punksecurity/saist --llm openai filesystem /vulnerableapp` |
 | Change caching folder | `saist/main.py --llm openai --cache-folder /path/to/cache filesystem /path/to/code` |
 | Disable findings cache | `saist/main.py --llm openai --disable-caching filesystem /path/to/code` |
 ---

--- a/saist/latex/tex/style.tex
+++ b/saist/latex/tex/style.tex
@@ -17,6 +17,8 @@
     frame=lines,
     autogobble,
     linenos,
+    breaklines,
+    breakanywhere
 }
 
 \usepackage{graphicx}

--- a/saist/main.py
+++ b/saist/main.py
@@ -352,7 +352,7 @@ async def process_file(scm: Scm, llm, filename, patch_text, semaphore, disable_t
             result = await analyze_single_file(scm, llm, filename, patch_text, disable_tools)
         else:
             hash: str = await hash_file(scm, filename)
-            cache_file = cache_folder+hash+".json"
+            cache_file = cache_folder + "/" + hash + ".json"
             if not os.path.exists(cache_file):
                 result = await analyze_single_file(scm, llm, filename, patch_text, disable_tools)
                 store_findings_to_cache_file(filename, result, cache_file)
@@ -366,7 +366,7 @@ async def process_file(scm: Scm, llm, filename, patch_text, semaphore, disable_t
 async def generate_findings(scm, llm, app_files, max_concurrent, disable_tools, disable_caching, cache_folder):
     if disable_caching is False:
         if not os.path.exists(cache_folder) or not os.path.isdir(cache_folder):
-            os.makedirs(cache_folder)
+            os.makedirs(cache_folder, exist_ok=True)
     
     semaphore = asyncio.Semaphore(max_concurrent)
 

--- a/saist/main.py
+++ b/saist/main.py
@@ -28,13 +28,14 @@ from scm.adapters.github import Github
 from scm import Scm
 from shell import Shell
 from latex import Latex
-import hashlib
 
 from util.argparsing import parse_args
 
 from util.poem import poem
 
 from util.output import print_banner, write_csv
+
+from util.caching import *
 
 prompts = prompts()
 load_dotenv(".env")
@@ -214,7 +215,7 @@ async def main():
     # 3) Analyze each file in parallel
     print("🔍 Analyzing files for security issues...")
     max_workers = min(args.llm_rate_limit, len(app_files))
-    all_findings = await generate_findings(scm, llm, app_files, max_workers, args.disable_tools)
+    all_findings = await generate_findings(scm, llm, app_files, max_workers, args.disable_tools, args.disable_caching)
 
     if not all_findings:
         print("✅ No findings reported. Exiting.\n")
@@ -345,45 +346,36 @@ async def main():
     if args.ci and len(all_findings) > 0:
         exit(1)
 
-async def hash_file(scm: Scm, filename: str) -> str:
-    file: str = await scm.read_file_contents(filename)
-    return hashlib.md5(file.encode()).hexdigest()
-
-def finding_from_json_cache(json_dict: dict[str, any]) -> Finding:
-    return Finding.model_validate(json_dict)
-
-async def process_file(scm: Scm, llm, filename, patch_text, semaphore, disable_tools):
+async def process_file(scm: Scm, llm, filename, patch_text, semaphore, disable_tools, disable_caching):
     async with semaphore:
         start = asyncio.get_event_loop().time()
-        #TODO: Pass cache folder into process file `SAISTCache/`
-        hash: str = await hash_file(scm, filename)
-        cache_file = "SAISTCache/"+hash+".json";
-        if not os.path.exists(cache_file):
+        #TODO: Pass cache folder into process_file `SAISTCache/`
+        #      Maybe with argument for cache folder name?
+        if disable_caching is True: 
             result = await analyze_single_file(scm, llm, filename, patch_text, disable_tools)
-            cache_dict: dict[str, list[Finding] | str] = { 
-                "path": filename,
-                "findings": result,
-            }
-            with open(cache_file, "w") as cf:
-                json.dump(cache_dict, cf, cls=FindingJSONEncoder)
         else:
-            with open(cache_file, 'r') as file:
-                cache_json: dict[str, list[dict] | str] = json.load(file, object_hook=dict[str, list[dict] | str]) #TODO: custom object_hook to parse into list[findings]
-                return [finding_from_json_cache(json_dict) for json_dict in cache_json["findings"]]
+            hash: str = await hash_file(scm, filename)
+            cache_file = "SAISTCache/"+hash+".json";
+            if not os.path.exists(cache_file):
+                result = await analyze_single_file(scm, llm, filename, patch_text, disable_tools)
+                store_findings_to_cache_file(filename, result, cache_file)
+            else:
+                result = findings_from_cache_file(cache_file)
         elapsed = asyncio.get_event_loop().time() - start
         if elapsed < 1:
             await asyncio.sleep(1 - elapsed)
     return result
 
-async def generate_findings(scm, llm, app_files, max_concurrent, disable_tools):
-    cache_folder: str = "SAISTCache/"
-    if not os.path.exists(cache_folder) or not os.path.isdir(cache_folder):
-        os.makedirs(cache_folder)
+async def generate_findings(scm, llm, app_files, max_concurrent, disable_tools, disable_caching):
+    if disable_caching is False:
+        cache_folder: str = "SAISTCache/"
+        if not os.path.exists(cache_folder) or not os.path.isdir(cache_folder):
+            os.makedirs(cache_folder)
     
     semaphore = asyncio.Semaphore(max_concurrent)
 
     tasks = [
-        process_file(scm, llm, filename, patch_text, semaphore, disable_tools)
+        process_file(scm, llm, filename, patch_text, semaphore, disable_tools, disable_caching)
         for filename, patch_text in app_files
     ]
 

--- a/saist/main.py
+++ b/saist/main.py
@@ -352,7 +352,7 @@ async def process_file(scm: Scm, llm, filename, patch_text, semaphore, disable_t
             result = await analyze_single_file(scm, llm, filename, patch_text, disable_tools)
         else:
             hash: str = await hash_file(scm, filename)
-            cache_file = cache_folder + "/" + hash + ".json"
+            cache_file = os.path.join(cache_folder, hash + ".json")
             if not os.path.exists(cache_file):
                 result = await analyze_single_file(scm, llm, filename, patch_text, disable_tools)
                 store_findings_to_cache_file(filename, result, cache_file)

--- a/saist/main.py
+++ b/saist/main.py
@@ -2,7 +2,6 @@
 import asyncio
 import logging
 import os
-import json
 
 from typing import Optional
 
@@ -14,7 +13,7 @@ from llm.adapters.gemini import GeminiAdapter
 from llm.adapters.openai import OpenAiAdapter
 from llm.adapters.ollama import OllamaAdapter
 from llm.adapters.faike import FaikeAdapter
-from models import FindingContext, FindingEnriched, Finding, Findings, FindingJSONEncoder
+from models import FindingContext, FindingEnriched, Finding, Findings
 from llm.adapters.anthropic import AnthropicAdapter
 from llm.adapters.bedrock import BedrockAdapter
 from web import FindingsServer

--- a/saist/models.py
+++ b/saist/models.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Annotated
-from json import JSONEncoder, JSONDecoder
+from json import JSONEncoder
 
 class Finding(BaseModel):
     file: str

--- a/saist/models.py
+++ b/saist/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Annotated
+from json import JSONEncoder, JSONDecoder
 
 class Finding(BaseModel):
     file: str
@@ -10,6 +11,12 @@ class Finding(BaseModel):
     cwe: Annotated[str, Field(description= "CWE id, should conform to CWE-XX or CWE-XXX where X is a number") ]
     priority: int
     line_number: int
+
+class FindingJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Finding):
+            return obj.__dict__
+        return super().default(object)
 
 class Findings(BaseModel):
     findings: list[Finding]

--- a/saist/util/argparsing.py
+++ b/saist/util/argparsing.py
@@ -209,6 +209,11 @@ parser.add_argument(
     )
 
 parser.add_argument(
+    "--disable-caching", help = "Disable local caching of results",
+      action='store_true', required=False
+    )
+
+parser.add_argument(
     "-v",
     "--verbose",
     action="count",

--- a/saist/util/argparsing.py
+++ b/saist/util/argparsing.py
@@ -215,7 +215,7 @@ parser.add_argument(
 
 parser.add_argument(
     "--cache-folder", type=str, help = "Folder name for local caching",
-    envvar="SAIST_CACHE_FOLDER", action=EnvDefault, required=False, default="SAISTCache/"
+    envvar="SAIST_CACHE_FOLDER", action=EnvDefault, required=False, default="SAISTCache"
     )
 
 parser.add_argument(

--- a/saist/util/argparsing.py
+++ b/saist/util/argparsing.py
@@ -214,6 +214,11 @@ parser.add_argument(
     )
 
 parser.add_argument(
+    "--cache-folder", type=str, help = "Folder name for local caching",
+    envvar="SAIST_CACHE_FOLDER", action=EnvDefault, required=False, default="SAISTCache/"
+    )
+
+parser.add_argument(
     "-v",
     "--verbose",
     action="count",

--- a/saist/util/caching.py
+++ b/saist/util/caching.py
@@ -1,0 +1,24 @@
+from scm import Scm
+from models import Finding
+import hashlib
+import json
+
+async def hash_file(scm: Scm, filename: str) -> str:
+    file: str = await scm.read_file_contents(filename)
+    return hashlib.md5(file.encode()).hexdigest()
+
+def finding_from_json_cache(json_dict: dict[str, any]) -> Finding:
+    return Finding.model_validate(json_dict)
+
+def findings_from_cache_file(cache_file: str) -> list[Finding]:
+    with open(cache_file, 'r') as file:
+        cache_json: dict[str, list[dict] | str] = json.load(file, object_hook=dict[str, list[dict] | str])
+        return [finding_from_json_cache(json_dict) for json_dict in cache_json["findings"]]
+
+def store_findings_to_cache_file(filename: str, findings: list[Finding], cache_file: str):
+    cache_dict: dict[str, list[Finding] | str] = { 
+            "path": filename,
+            "findings": findings,
+        }
+    with open(cache_file, "w") as cf:
+        json.dump(cache_dict, cf, cls=FindingJSONEncoder)

--- a/saist/util/caching.py
+++ b/saist/util/caching.py
@@ -11,7 +11,7 @@ def finding_from_json_cache(json_dict: dict[str, any]) -> Finding:
     return Finding.model_validate(json_dict)
 
 def findings_from_cache_file(cache_file: str) -> list[Finding]:
-    with open(cache_file, 'r') as file:
+    with open(cache_file, 'r', encoding="utf-8") as file:
         cache_json: dict[str, list[dict] | str] = json.load(file, object_hook=dict[str, list[dict] | str])
         return [finding_from_json_cache(json_dict) for json_dict in cache_json["findings"]]
 
@@ -20,5 +20,5 @@ def store_findings_to_cache_file(filename: str, findings: list[Finding], cache_f
             "path": filename,
             "findings": findings,
         }
-    with open(cache_file, "w") as cf:
+    with open(cache_file, "w", encoding="utf-8") as cf:
         json.dump(cache_dict, cf, cls=FindingJSONEncoder)

--- a/saist/util/caching.py
+++ b/saist/util/caching.py
@@ -5,7 +5,7 @@ import json
 
 async def hash_file(scm: Scm, filename: str) -> str:
     file: str = await scm.read_file_contents(filename)
-    return hashlib.md5(file.encode()).hexdigest()
+    return hashlib.sha256(file.encode()).hexdigest()
 
 def finding_from_json_cache(json_dict: dict[str, any]) -> Finding:
     return Finding.model_validate(json_dict)

--- a/saist/util/caching.py
+++ b/saist/util/caching.py
@@ -1,5 +1,5 @@
 from scm import Scm
-from models import Finding
+from models import Finding, FindingJSONEncoder
 import hashlib
 import json
 


### PR DESCRIPTION
Simple fix that alters the minted config in style.tex, adding breaklines and breakanywhere.

This fixes code snippets in pdf reports extending past the right side of the pdf

fixes: #32