### PR TITLE
Add breaklines and breakanywhere to minted's config in style.tex

### DIFF
--- a/saist/latex/tex/style.tex
+++ b/saist/latex/tex/style.tex
@@ -17,6 +17,8 @@
     frame=lines,
     autogobble,
     linenos,
+    breaklines,
+    breakanywhere
 }
 
 \usepackage{graphicx}


### PR DESCRIPTION
Added breaklines and breakanywhere to the minted config, allowing code snippets to be broken and split across two or more lines, instead of going off the right side of outputted pdf documents

fixes: #32 