### PR TITLE
Improve PDF output LaTeX escaping

### DIFF
--- a/saist/latex/__init__.py
+++ b/saist/latex/__init__.py
@@ -80,5 +80,5 @@ class Latex:
             return specials[char]
 
         # negative look-behind makes sure we don’t double-escape something like \%
-        pattern = r'(?<!\\)[&%$_{}#~^\\]'
+        pattern = r'.(?<=[&%$_{}#~^\\])'
         return re.sub(pattern, repl, text)

--- a/saist/latex/__init__.py
+++ b/saist/latex/__init__.py
@@ -79,6 +79,5 @@ class Latex:
             char = match.group(0)
             return specials[char]
 
-        # negative look-behind makes sure we don’t double-escape something like \%
         pattern = r'.(?<=[&%$_{}#~^\\])'
         return re.sub(pattern, repl, text)

--- a/saist/latex/tex/style.tex
+++ b/saist/latex/tex/style.tex
@@ -1,4 +1,5 @@
 \documentclass[titlepage]{article}
+\usepackage[utf8]{inputenc}
 \usepackage[margin=0.8in]{geometry}
 \usepackage[parfill]{parskip}
 
@@ -43,3 +44,6 @@
     urlcolor =ColorPurple,            % \href links
     citecolor=ColorSecondary,         % bibliography
 ]{hyperref}
+
+\DeclareUnicodeCharacter{2264}{<=}
+\DeclareUnicodeCharacter{2265}{>=}


### PR DESCRIPTION
Ensured UTF-8 encoding in style.tex and added specific character mappings for ≥ and ≤

Modified the Regex in the latex output's __escape_tex function to correctly escape all special LaTeX command characters, regardless of what character is before or after them

fixes: #34