### PR TITLE
Add more information to the title page of PDF reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ export SAIST_LLM_API_KEY=your-api-key
 | Interactive shell after scanning | `saist/main.py --llm ollama --interactive filesystem /path/to/code` |
 | Export findings as CSV | `saist/main.py --llm openai --csv filesystem /path/to/code` |
 | Scan with docker and export findings as PDF report | `docker run -v <folder_path>:/vulnerableapp -v $PWD/reporting:/app/reporting punksecurity/saist --llm openai --pdf filesystem /vulnerableapp` |
+| Scan with docker and export findings as PDF report with a project title | `docker run -v <folder_path>:/vulnerableapp -v $PWD/reporting:/app/reporting punksecurity/saist --llm openai --pdf --project-name "Project Name" filesystem /vulnerableapp` |
 | Scan with docker and retain cache for future runs | `docker run -v <folder_path>:/vulnerableapp -v $PWD/SAISTCache:/app/SAISTCache punksecurity/saist --llm openai filesystem /vulnerableapp` |
 | Change caching folder | `saist/main.py --llm openai --cache-folder /path/to/cache filesystem /path/to/code` |
 | Disable findings cache | `saist/main.py --llm openai --disable-caching filesystem /path/to/code` |
@@ -135,6 +136,8 @@ To create a PDF report, simply use the `--pdf` flag when running the scan. By de
 `reporting/report.pdf`. You can customize the filename by using the `--pdf-filename` option followed by your desired
 filename.
 
+To add a project name onto the title page of the PDF report, use the `--project-name` option followed by your desired title.
+
 > It is recommended to use the provided Docker image for generating PDF reports, as it includes the necessary TeX suite,
 which can be quite large. This ensures that all dependencies are met and the report is generated properly.
 
@@ -169,6 +172,7 @@ docker run -v$PWD/code:/code -v$PWD/reporting:/app/reporting punksecurity/saist 
 | `--cache-folder` | Change the default cache folder |
 | `--csv` | Output findings to `findings.csv` |
 | `--pdf` | Output findings to PDF report (`report.pdf`) |
+| `--project-name` | Set the project name for the PDF report's title page (e.g. `"Project name"`) |
 | `--ci` | Exit with code 1 if vulnerabilities found |
 | `-v, --verbose` | Increase output verbosity |
 | _Git-specific:_ |

--- a/saist/latex/tex/report.tex.jinja
+++ b/saist/latex/tex/report.tex.jinja
@@ -7,7 +7,18 @@
     \vspace*{5cm}
     \includegraphics[width=0.4\textwidth]{\LogoTitlepage}\\[0.5cm]
 {\Huge\sffamily\bfseries\color{ColorSecondary}{AI generated code review}\\[0.75em]
-\Large\sffamily created by \href{https://github.com/punk-security/SAIST}{\textbf{SAIST}}}
+\Large\sffamily created by \href{https://github.com/punk-security/SAIST}{\textbf{SAIST}}}\\[0.75em]
+{%- if model.model_vendor is not none -%}
+\Large\sffamily\color{ColorSecondary}{{ escape_tex(model.model_vendor) }}: 
+{%- endif -%}
+\Large\sffamily\color{ColorSecondary}{{ escape_tex(model.model_name) }}
+{%- if project is not none -%}
+  \\[0.75em]
+  \Large\sffamily\color{ColorSecondary}{{ escape_tex(project) }}\\[0.75em]
+{%- endif -%}
+
+\vspace{2.5cm}
+\centering\Large\sffamily\color{ColorSecondary}{{ now }}
 
 \end{titlepage}
 

--- a/saist/llm/adapters/__init__.py
+++ b/saist/llm/adapters/__init__.py
@@ -11,6 +11,8 @@ logger = logging.getLogger("saist.llm.adapters")
 
 class BaseLlmAdapter:
     model_options = None
+    model_vendor = ''
+    model_name = ''
 
     def get_model_options(self):
         return {'temperature': 0.0} | self.model_options if self.model_options is not None else {}

--- a/saist/llm/adapters/anthropic.py
+++ b/saist/llm/adapters/anthropic.py
@@ -14,5 +14,6 @@ class AnthropicAdapter(BaseLlmAdapter):
             provider = AnthropicProvider( api_key=api_key )
         )
         self.model_name = self.model.model_name
+        self.model_vendor = 'Anthropic'
 
         self.model_options = {'max_tokens': 8192}

--- a/saist/llm/adapters/bedrock.py
+++ b/saist/llm/adapters/bedrock.py
@@ -12,4 +12,6 @@ class BedrockAdapter(BaseLlmAdapter):
             model = "anthropic.claude-3-sonnet-20240229-v1:0"
         self.model = BedrockConverseModel( model )
         self.model_name = self.model.model_name
+        self.model_vendor = 'Bedrock'
+
 

--- a/saist/llm/adapters/deepseek.py
+++ b/saist/llm/adapters/deepseek.py
@@ -14,3 +14,5 @@ class DeepseekAdapter(BaseLlmAdapter):
             provider = DeepSeekProvider( api_key=api_key ),
         )
         self.model_name = self.model.model_name
+        self.model_vendor = 'DeepSeek'
+

--- a/saist/llm/adapters/faike.py
+++ b/saist/llm/adapters/faike.py
@@ -13,6 +13,7 @@ class FaikeAdapter(BaseLlmAdapter):
     def __init__(self, base_url: str, model: str = None, api_key: Optional[str] = None):
         self.model = model
         self.model_name = self.model
+        self.model_vendor = 'Fake AI LLM'
 
     async def prompt_structured(self, system_prompt: str, user_prompt: str, response_format: Type[BaseModel], tool_fns: Optional[List[Callable]] = None) -> BaseModel:
         logger.getChild(self.__class__.__name__).debug("prompt_structured initial response", extra={'prompt': user_prompt})

--- a/saist/llm/adapters/gemini.py
+++ b/saist/llm/adapters/gemini.py
@@ -14,3 +14,4 @@ class GeminiAdapter(BaseLlmAdapter):
             provider = GoogleGLAProvider( api_key=api_key )
         )
         self.model_name = self.model.model_name
+        self.model_vendor = 'Google-gla'

--- a/saist/llm/adapters/ollama.py
+++ b/saist/llm/adapters/ollama.py
@@ -16,6 +16,7 @@ class OllamaAdapter(BaseLlmAdapter):
         self.model = model
         self.model_name = self.model
         self.client = ollama.AsyncClient(host=base_url)
+        self.model_vendor = 'Ollama'
 
 
     async def initialize(self):

--- a/saist/llm/adapters/openai.py
+++ b/saist/llm/adapters/openai.py
@@ -14,3 +14,4 @@ class OpenAiAdapter(BaseLlmAdapter):
             provider = OpenAIProvider( api_key=api_key )
         )
         self.model_name = self.model.model_name
+        self.model_vendor = 'OpenAI'

--- a/saist/main.py
+++ b/saist/main.py
@@ -339,7 +339,7 @@ async def main():
                 findings_context.append(fc)
             except:
                 continue
-        l = Latex(findings_context, comment)
+        l = Latex(llm, args.project_name, findings_context, comment)
         l.run(args)
 
     if args.ci and len(all_findings) > 0:
@@ -360,7 +360,7 @@ async def process_file(scm: Scm, llm, filename, patch_text, semaphore, disable_t
                 result = findings_from_cache_file(cache_file)
         elapsed = asyncio.get_event_loop().time() - start
         if elapsed < 1:
-            await asyncio.sleep(1 - elapsed)
+            await asyncio.sleep(1 - elapsed) 
     return result
 
 async def generate_findings(scm, llm, app_files, max_concurrent, disable_tools, disable_caching, cache_folder):

--- a/saist/util/argparsing.py
+++ b/saist/util/argparsing.py
@@ -219,6 +219,11 @@ parser.add_argument(
     )
 
 parser.add_argument(
+    "--project-name", type=str, help = "Project name for pdf output",
+    envvar="SAIST_PROJECT_NAME", action=EnvDefault, required=False, default=""
+    )
+
+parser.add_argument(
     "-v",
     "--verbose",
     action="count",


### PR DESCRIPTION
Added the LLM vendor and model names, project name, and timestamp onto the title page of LaTeX and PDF outputs.

Also added the option `--project-name` to set the project name that will appear on the title page.

resolves: #29 